### PR TITLE
Fix test. Replace the literal to the const

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ module.exports = (dirname, name) => {
     write: (obj) => new Promise((resolve, reject) => {
       jsonfile.writeFile(fullpath, obj, (err) => {
         if (err) return reject(err);
-        fs.chmodSync(fullpath, 0600);
+        //same as chmod 600
+        fs.chmodSync(fullpath, fs.constants.S_IRUSR | fs.constants.S_IWUSR);
         resolve(obj);
       });
     }),

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = (dirname, name) => {
     write: (obj) => new Promise((resolve, reject) => {
       jsonfile.writeFile(fullpath, obj, (err) => {
         if (err) return reject(err);
-        //same as chmod 600
+        // same as chmod 600
         fs.chmodSync(fullpath, fs.constants.S_IRUSR | fs.constants.S_IWUSR);
         resolve(obj);
       });

--- a/test.js
+++ b/test.js
@@ -14,12 +14,10 @@ test('write', async (t) => {
   const dotlocal = dotf(__dirname, 'myignore1'); // Local (./)
   const writeGlobal = await dotglobal.write({a: 1});
   const writeLocal = await dotlocal.write({a: 1});
-  if ('600' !== (fs.statSync(dotglobalfullpath).mode &&
-      parseInt(777, 8)).toString(8)) {
+  if ('600' !== (fs.statSync(dotglobalfullpath).mode & parseInt(777, 8)).toString(8)) {
     t.fail();
   }
-  if ('600' !== (fs.statSync(dotlocalfullpath).mode &&
-      parseInt(777, 8)).toString(8)) {
+  if ('600' !== (fs.statSync(dotlocalfullpath).mode & parseInt(777, 8)).toString(8)) {
     t.fail();
   }
   t.pass();

--- a/test.js
+++ b/test.js
@@ -17,12 +17,12 @@ test('write', async (t) => {
 
   // If file permission is incorrect,
   // {{file permission value} logical AND {777 in octal}}
-  // != {correct permission value}.
-  if ((fs.statSync(dotglobalfullpath).mode & 0o777) != (fs.constants.S_IRUSR
+  // !== {correct permission value}.
+  if ((fs.statSync(dotglobalfullpath).mode & 0o777) !== (fs.constants.S_IRUSR
      | fs.constants.S_IWUSR)) {
     t.fail();
   }
-  if ((fs.statSync(dotlocalfullpath).mode & 0o777) != (fs.constants.S_IRUSR
+  if ((fs.statSync(dotlocalfullpath).mode & 0o777) !== (fs.constants.S_IRUSR
      | fs.constants.S_IWUSR)) {
     t.fail();
   }

--- a/test.js
+++ b/test.js
@@ -14,10 +14,12 @@ test('write', async (t) => {
   const dotlocal = dotf(__dirname, 'myignore1'); // Local (./)
   const writeGlobal = await dotglobal.write({a: 1});
   const writeLocal = await dotlocal.write({a: 1});
-  if ('600' !== (fs.statSync(dotglobalfullpath).mode & parseInt(777, 8)).toString(8)) {
+
+  //If file permission is incorrect, {{file permission value} logical AND {777 in octal}} != {correct permission value}.
+  if ((fs.statSync(dotglobalfullpath).mode & 0o777) != (fs.constants.S_IRUSR | fs.constants.S_IWUSR)) {
     t.fail();
   }
-  if ('600' !== (fs.statSync(dotlocalfullpath).mode & parseInt(777, 8)).toString(8)) {
+  if ((fs.statSync(dotlocalfullpath).mode & 0o777) != (fs.constants.S_IRUSR | fs.constants.S_IWUSR)) {
     t.fail();
   }
   t.pass();

--- a/test.js
+++ b/test.js
@@ -15,11 +15,15 @@ test('write', async (t) => {
   const writeGlobal = await dotglobal.write({a: 1});
   const writeLocal = await dotlocal.write({a: 1});
 
-  //If file permission is incorrect, {{file permission value} logical AND {777 in octal}} != {correct permission value}.
-  if ((fs.statSync(dotglobalfullpath).mode & 0o777) != (fs.constants.S_IRUSR | fs.constants.S_IWUSR)) {
+  // If file permission is incorrect,
+  // {{file permission value} logical AND {777 in octal}}
+  // != {correct permission value}.
+  if ((fs.statSync(dotglobalfullpath).mode & 0o777) != (fs.constants.S_IRUSR
+     | fs.constants.S_IWUSR)) {
     t.fail();
   }
-  if ((fs.statSync(dotlocalfullpath).mode & 0o777) != (fs.constants.S_IRUSR | fs.constants.S_IWUSR)) {
+  if ((fs.statSync(dotlocalfullpath).mode & 0o777) != (fs.constants.S_IRUSR
+     | fs.constants.S_IWUSR)) {
     t.fail();
   }
   t.pass();


### PR DESCRIPTION
Fix test for permission.  
Replace the literal(0600) to the const(fs.constants.S_IRUSR | fs.constants.S_IWUSR).  

 - [x] npm run test succeeds.