### PR TITLE
disable-chmodSync-on-windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,11 @@ module.exports = (dirname, name) => {
     write: (obj) => new Promise((resolve, reject) => {
       jsonfile.writeFile(fullpath, obj, (err) => {
         if (err) return reject(err);
-        // same as chmod 600
-        fs.chmodSync(fullpath, fs.constants.S_IRUSR | fs.constants.S_IWUSR);
+        // if a platform is not Windows(include x64)
+        if ('win32' !== process.platform) {
+          // same as chmod 600
+          fs.chmodSync(fullpath, fs.constants.S_IRUSR | fs.constants.S_IWUSR);
+        }
         resolve(obj);
       });
     }),

--- a/test.js
+++ b/test.js
@@ -15,16 +15,19 @@ test('write', async (t) => {
   const writeGlobal = await dotglobal.write({a: 1});
   const writeLocal = await dotlocal.write({a: 1});
 
-  // If file permission is incorrect,
-  // {{file permission value} logical AND {777 in octal}}
-  // !== {correct permission value}.
-  if ((fs.statSync(dotglobalfullpath).mode & 0o777) !== (fs.constants.S_IRUSR
-     | fs.constants.S_IWUSR)) {
-    t.fail();
-  }
-  if ((fs.statSync(dotlocalfullpath).mode & 0o777) !== (fs.constants.S_IRUSR
-     | fs.constants.S_IWUSR)) {
-    t.fail();
+  // if a platform is not Windows(include x64)
+  if ('win32' !== process.platform) {
+    // If file permission is incorrect,
+    // {{file permission value} logical AND {777 in octal}}
+    // !== {correct permission value}.
+    if ((fs.statSync(dotglobalfullpath).mode & 0o777) !== (fs.constants.S_IRUSR
+      | fs.constants.S_IWUSR)) {
+      t.fail();
+    }
+    if ((fs.statSync(dotlocalfullpath).mode & 0o777) !== (fs.constants.S_IRUSR
+      | fs.constants.S_IWUSR)) {
+      t.fail();
+    }
   }
   t.pass();
   await dotglobal.delete();


### PR DESCRIPTION
Disable chmodSync on Windows.  
Fix  https://github.com/google/clasp/issues/409.

 - [x] npm run lint succeeds.
 - [x] npm run test succeeds on MacOS 10.13.6/Windows 8.1.