### PR TITLE
Esmoduleinterop enable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4509,9 +4509,9 @@
       "dev": true
     },
     "ts-node": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.2.0.tgz",
-      "integrity": "sha512-m8XQwUurkbYqXrKqr3WHCW310utRNvV5OnRVeISeea7LoCWVcdfeB/Ntl8JYWFh+WRoUAdBgESrzKochQt7sMw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
+      "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
@@ -4528,9 +4528,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.17.0.tgz",
-      "integrity": "sha512-pflx87WfVoYepTet3xLfDOLDm9Jqi61UXIKePOuca0qoAZyrGWonDG9VTbji58Fy+8gciUn8Bt7y69+KEVjc/w==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.18.0.tgz",
+      "integrity": "sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -4581,9 +4581,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
-      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "@types/node": "^8.10.49",
     "ava": "^2.1.0",
     "c8": "^5.0.1",
-    "ts-node": "^8.2.0",
-    "tslint": "^5.17.0",
-    "typescript": "^3.5.1"
+    "ts-node": "^8.3.0",
+    "tslint": "^5.18.0",
+    "typescript": "^3.5.2"
   },
   "ava": {
     "compileEnhancements": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "es2018"
     ],
     "module": "commonjs",
+    "esModuleInterop": true,
     "moduleResolution": "node",
     "strict": true,
     // "inlineSourceMap": true,


### PR DESCRIPTION
No impact for typescript specific `import * as xxx` syntax was not in use